### PR TITLE
feat: add --version flag to root command

### DIFF
--- a/data_for_test.go
+++ b/data_for_test.go
@@ -1373,4 +1373,29 @@ var suites = []FixtureSuite{
 			},
 		},
 	},
+	// version flag tests
+	{
+		{
+			Name: "version subcommand",
+			Config: FixtureConfig{
+				CliArgs: []string{"version"},
+			},
+			Expect: Results{
+				CliOutput:   "\n",
+				CliOutputRe: regexp.MustCompile(`\S+`),
+				ExitCode:    0,
+			},
+		},
+		{
+			Name: "--version flag",
+			Config: FixtureConfig{
+				CliArgs: []string{"--version"},
+			},
+			Expect: Results{
+				CliOutput:   "\n",
+				CliOutputRe: regexp.MustCompile(`otel-cli version \S+`),
+				ExitCode:    0,
+			},
+		},
+	},
 }

--- a/otelcli/root.go
+++ b/otelcli/root.go
@@ -59,6 +59,7 @@ func createRootCmd(config *Config) *cobra.Command {
 
 	cobra.EnableCommandSorting = false
 	rootCmd.Flags().SortFlags = false
+	rootCmd.Version = config.Version
 
 	Diag.NumArgs = len(os.Args) - 1
 	Diag.CliArgs = []string{}


### PR DESCRIPTION
## Summary

Adds support for  flag (and  short form) to otel-cli, following standard CLI conventions.

## Changes

- ✅ Set  in  to enable Cobra's built-in version flag
- ✅ Added functional tests for both  subcommand and  flag
- ✅ Tests verify output format and exit code 0
- ✅ All tests pass

## Testing

### Functional tests added:
1. **version subcommand** - tests  works correctly
2. **--version flag** - tests  works correctly

Both test that:
- Output contains version information
- Exit code is 0

### Manual testing:
```bash
$ ./otel-cli --version
otel-cli version 0.6.0-test test123 2025-11-09

$ ./otel-cli -v
otel-cli version 0.6.0-test test123 2025-11-09

$ ./otel-cli version
0.6.0-test test123 2025-11-09
```

## Related

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>