### PR TITLE
fix: add TLS credentials support to gRPC server

### DIFF
--- a/otlpserver/grpcserver.go
+++ b/otlpserver/grpcserver.go
@@ -26,10 +26,11 @@ type GrpcServer struct {
 }
 
 // NewGrpcServer takes a callback and stop function and returns a Server ready
-// to run with .Serve().
-func NewGrpcServer(cb Callback, stop Stopper) *GrpcServer {
+// to run with .Serve(). Optional grpc.ServerOption arguments can be provided
+// for TLS configuration and other server options.
+func NewGrpcServer(cb Callback, stop Stopper, opts ...grpc.ServerOption) *GrpcServer {
 	s := GrpcServer{
-		server:   grpc.NewServer(),
+		server:   grpc.NewServer(opts...),
 		callback: cb,
 		stopper:  make(chan struct{}),
 		stopdone: make(chan struct{}, 1),


### PR DESCRIPTION
## Summary

Fixes the TLS gRPC test timeouts by properly configuring gRPC server credentials.

## Problem

Two TLS-related gRPC tests were timing out:
- `minimum configuration (tls, no-verify, recording, grpc)`
- `minimum configuration (tls, client cert auth, recording, grpc)`

The root cause: gRPC requires TLS credentials to be configured in the server itself via `grpc.Creds()`, not just passed through a TLS listener. HTTP and gRPC handle TLS fundamentally differently.

## Solution

**Updated `NewGrpcServer`:**
- Added variadic `grpc.ServerOption` parameter for TLS and other configurations
- Backwards compatible - existing calls work without changes

**Updated `NewServer`:**
- Added optional `*tls.Config` parameter
- Converts TLS config to `grpc.Creds()` for gRPC servers
- HTTP servers unchanged (they use TLS listeners)

**Updated test harness:**
- Passes TLS config to gRPC servers when `ServerTLSEnabled` is true
- gRPC uses plain listener + server credentials
- HTTP continues using TLS listener

## Test Results

```bash
$ go test
PASS
ok  	github.com/tobert/otel-cli	1.019s
```

Both previously-failing TLS gRPC tests now pass! ✅

## Breaking Changes

None - all changes are backwards compatible.

Fixes #17

Co-Authored-By: Claude <claude@anthropic.com>