### PR TITLE
fix(span): skip zero parent span id from empty traceparent (#23)

### DIFF
--- a/data_for_test.go
+++ b/data_for_test.go
@@ -1243,6 +1243,32 @@ var suites = []FixtureSuite{
 			},
 		},
 	},
+	// #23: --tp-ignore-env should not produce a zero-valued parent span id
+	{
+		{
+			Name: "#23 --tp-ignore-env should not send zero parent span id",
+			Config: FixtureConfig{
+				CliArgs: []string{
+					"span",
+					"--endpoint", "{{endpoint}}",
+					"--tp-ignore-env",
+					"--name", "test-tp-ignore",
+				},
+				Env: map[string]string{
+					"TRACEPARENT": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+				},
+			},
+			Expect: Results{
+				Config: otelcli.DefaultConfig(),
+				SpanData: map[string]string{
+					"trace_id":       "*",
+					"span_id":        "*",
+					"parent_span_id": "",
+				},
+				SpanCount: 1,
+			},
+		},
+	},
 	// full-system test --otlp-headers makes it to grpc/http servers
 	{
 		{

--- a/otelcli/config_span.go
+++ b/otelcli/config_span.go
@@ -1,6 +1,7 @@
 package otelcli
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -42,7 +43,10 @@ func (c Config) NewProtobufSpan() *tracepb.Span {
 		tp := c.LoadTraceparent()
 		if tp.Initialized {
 			span.TraceId = tp.TraceId
-			span.ParentSpanId = tp.SpanId
+			// only set parent span id when the traceparent has a real (non-zero) span id (#23)
+			if !bytes.Equal(tp.SpanId, otlpclient.GetEmptySpanId()) {
+				span.ParentSpanId = tp.SpanId
+			}
 		}
 	} else {
 		span.TraceId = otlpclient.GetEmptyTraceId()


### PR DESCRIPTION
## Summary
- When `--tp-ignore-env` is set, `LoadTraceparent()` returns a traceparent with `Initialized=true` but zeroed SpanId
- The code unconditionally set `ParentSpanId = tp.SpanId`, producing a span with an all-zeros parent
- Now checks `bytes.Equal` against `GetEmptySpanId()` before setting parent span id
- Added functional test that verifies `--tp-ignore-env` produces empty parent span id

## Test plan
- [x] New functional test in `data_for_test.go`: `--tp-ignore-env` with TRACEPARENT set, verify parent_span_id is empty
- [x] All existing tests pass (`go test && go test ./...`)

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)