### PR TITLE
fix(exec): preserve child exit code when OTLP export fails (#360)

### DIFF
--- a/data_for_test.go
+++ b/data_for_test.go
@@ -568,6 +568,32 @@ var suites = []FixtureSuite{
 			},
 		},
 	},
+	// #360: exec child exit code should propagate even when OTLP export fails
+	{
+		{
+			Name: "#360 exec child exit code preserved when export fails",
+			Config: FixtureConfig{
+				CliArgs: []string{"exec",
+					"--endpoint", "{{endpoint}}",
+					"--timeout", "100ms",
+					"--", "/bin/sh", "-c", "exit 42",
+				},
+				StopServerBeforeExec: true,
+				TestTimeoutMs:        2000,
+				IsLongTest:           true,
+			},
+			Expect: Results{
+				Config: otelcli.DefaultConfig(),
+			},
+			CheckFuncs: []CheckFunc{
+				func(t *testing.T, f Fixture, r Results) {
+					if r.ExitCode != 42 {
+						t.Errorf("expected exit code 42 from child process, got %d", r.ExitCode)
+					}
+				},
+			},
+		},
+	},
 	// otel-cli span with no OTLP config should do and print nothing
 	{
 		{

--- a/otelcli/config.go
+++ b/otelcli/config.go
@@ -373,10 +373,15 @@ func (c Config) SoftLogIfErr(err error) {
 }
 
 // SoftFail calls through to softLog (which logs only if otel-cli was run with the --verbose
-// flag), then immediately exits - with status -1 by default, or 1 if --fail was
-// set (a la `curl --fail`)
+// flag), then immediately exits. When a child process exit code has been captured (e.g. from
+// exec), that code is preserved. Otherwise exits 0 by default, or 1 with --fail.
 func (c Config) SoftFail(format string, a ...interface{}) {
 	c.SoftLog(format, a...)
+
+	// preserve exec child exit code when available (#360)
+	if Diag.ExecExitCode != 0 {
+		os.Exit(Diag.ExecExitCode)
+	}
 
 	if c.Fail {
 		os.Exit(1)


### PR DESCRIPTION
SoftFail lost child exit code when OTLP export failed. Now captures ExecExitCode before export and SoftFail uses it when non-zero. Fixes #360