### PR TITLE
feat(propagation): adopt envcar carrier for TRACEPARENT

### DIFF
--- a/data_for_test.go
+++ b/data_for_test.go
@@ -1070,6 +1070,28 @@ var suites = []FixtureSuite{
 			},
 		},
 	},
+	// #390: otel-cli accepts a lenient (upper-case) TRACEPARENT but only ever
+	// emits strict, spec-valid lower-case W3C into the child process env.
+	{
+		{
+			Name: "otel-cli exec normalizes an upper-case TRACEPARENT into the child env",
+			Config: FixtureConfig{
+				CliArgs: []string{
+					"exec", "--endpoint", "{{endpoint}}",
+					"--force-span-id", "023eee2731392b4d",
+					"--",
+					"sh", "-c", "echo $TRACEPARENT"},
+				Env: map[string]string{
+					"TRACEPARENT": "00-E39280F2980AF3A8600AE98C74F2DABF-BBBBBBBBBBBBBBBB-01",
+				},
+			},
+			Expect: Results{
+				Config:    otelcli.DefaultConfig().WithEndpoint("{{endpoint}}"),
+				CliOutput: "00-e39280f2980af3a8600ae98c74f2dabf-023eee2731392b4d-01\n",
+				SpanCount: 1,
+			},
+		},
+	},
 	// validate OTEL_EXPORTER_OTLP_PROTOCOL / --protocol
 	{
 		// --protocol

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,10 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/pterm/pterm v0.12.83
 	github.com/spf13/cobra v1.10.2
+	go.opentelemetry.io/contrib/propagators/envcar v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
+	go.opentelemetry.io/otel/trace v1.44.0
 	go.opentelemetry.io/proto/otlp v1.10.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d
 	google.golang.org/grpc v1.81.1
@@ -33,7 +35,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
-	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/propagators/envcar v0.69.0 h1:AXf4SXMcQRyMJMgHKzcYA1bvp4PgyMzU6YiUu2xAD5I=
+go.opentelemetry.io/contrib/propagators/envcar v0.69.0/go.mod h1:p2SyHfaQ06uU9wSNypRDRQu567RL/KUUUnz+KbMUs7U=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=

--- a/otelcli/config_span.go
+++ b/otelcli/config_span.go
@@ -89,7 +89,7 @@ func (c Config) LoadTraceparent() traceparent.Traceparent {
 
 	if !c.TraceparentIgnoreEnv {
 		var err error
-		tp, err = traceparent.LoadFromEnv()
+		tp, err = envCarrierTraceparent()
 		if err != nil {
 			Diag.Error = err.Error()
 		}

--- a/otelcli/exec.go
+++ b/otelcli/exec.go
@@ -78,15 +78,16 @@ func doExec(cmd *cobra.Command, args []string) {
 	childEnv := []string{}
 
 	// set the traceparent to the current span to be available to the child process
+	appendChildEnv := func(key, value string) { childEnv = append(childEnv, key+"="+value) }
 	var tp traceparent.Traceparent
 	if config.GetIsRecording() {
 		tp = otlpclient.TraceparentFromProtobufSpan(span, config.GetIsRecording())
-		childEnv = append(childEnv, fmt.Sprintf("TRACEPARENT=%s", tp.Encode()))
+		injectTraceparent(tp, appendChildEnv)
 		// when not recording, and a traceparent is available, pass it through
 	} else if !config.TraceparentIgnoreEnv {
-		tp := config.LoadTraceparent()
-		if tp.Initialized {
-			childEnv = append(childEnv, fmt.Sprintf("TRACEPARENT=%s", tp.Encode()))
+		passthrough := config.LoadTraceparent()
+		if passthrough.Initialized {
+			injectTraceparent(passthrough, appendChildEnv)
 		}
 	}
 

--- a/otelcli/propagation.go
+++ b/otelcli/propagation.go
@@ -1,0 +1,65 @@
+package otelcli
+
+import (
+	"context"
+
+	"github.com/tobert/otel-cli/w3c/traceparent"
+	"go.opentelemetry.io/contrib/propagators/envcar"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// propagator is the OpenTelemetry propagator otel-cli uses to emit context into
+// child process environments. Routing emission through the standard W3C
+// propagator guarantees the output is always spec-valid: this is the strict
+// half of otel-cli's Postel's-law stance (accept leniently when parsing, only
+// ever emit valid W3C). TRACESTATE and BAGGAGE join via a composite propagator
+// in a follow-up.
+var propagator propagation.TextMapPropagator = propagation.TraceContext{}
+
+// envCarrierTraceparent reads a traceparent from the process environment using
+// the OpenTelemetry env-carrier key normalization, then parses the value with
+// otel-cli's lenient parser. Parsing leniency is deliberate: we accept input
+// the strict propagator would reject (e.g. upper-case hex) and canonicalize it.
+// An absent carrier yields an uninitialized Traceparent with no error.
+func envCarrierTraceparent() (traceparent.Traceparent, error) {
+	carrier := envcar.Carrier{}
+	raw := carrier.Get("traceparent")
+	if raw == "" {
+		return traceparent.Traceparent{}, nil
+	}
+	return traceparent.Parse(raw)
+}
+
+// injectTraceparent writes tp into a child process environment via setEnv,
+// routing through the standard W3C propagator so the emitted value is always
+// spec-valid. An invalid (e.g. all-zero) span context is silently not emitted
+// rather than propagating a context that downstream tooling would reject.
+func injectTraceparent(tp traceparent.Traceparent, setEnv func(key, value string)) {
+	sc := spanContextFromTraceparent(tp)
+	if !sc.IsValid() {
+		return
+	}
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+	propagator.Inject(ctx, &envcar.Carrier{SetEnvFunc: setEnv})
+}
+
+// spanContextFromTraceparent converts otel-cli's internal traceparent into the
+// SDK trace.SpanContext the propagator operates on.
+func spanContextFromTraceparent(tp traceparent.Traceparent) trace.SpanContext {
+	var traceID trace.TraceID
+	var spanID trace.SpanID
+	copy(traceID[:], tp.TraceId)
+	copy(spanID[:], tp.SpanId)
+
+	flags := trace.TraceFlags(0)
+	if tp.Sampling {
+		flags = trace.FlagsSampled
+	}
+
+	return trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: flags,
+	})
+}

--- a/otelcli/propagation_test.go
+++ b/otelcli/propagation_test.go
@@ -1,0 +1,74 @@
+package otelcli
+
+import (
+	"testing"
+)
+
+// TestEnvCarrierTraceparentGraceful proves Postel's law on the read side: we
+// accept input that the strict W3C propagator would reject (upper-case hex)
+// and downcase it into our canonical representation.
+func TestEnvCarrierTraceparentGraceful(t *testing.T) {
+	t.Setenv("TRACEPARENT", "00-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-BBBBBBBBBBBBBBBB-01")
+
+	tp, err := envCarrierTraceparent()
+	if err != nil {
+		t.Fatalf("envCarrierTraceparent() returned an unexpected error: %s", err)
+	}
+	if !tp.Initialized {
+		t.Fatal("expected an initialized traceparent from an upper-case TRACEPARENT")
+	}
+	if got := tp.TraceIdString(); got != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Errorf("trace id not downcased, got %q", got)
+	}
+	if got := tp.SpanIdString(); got != "bbbbbbbbbbbbbbbb" {
+		t.Errorf("span id not downcased, got %q", got)
+	}
+	if !tp.Sampling {
+		t.Error("expected the sampling flag to be set")
+	}
+}
+
+// TestEnvCarrierTraceparentEmpty proves an absent carrier yields an
+// uninitialized traceparent with no error, matching the historical contract.
+func TestEnvCarrierTraceparentEmpty(t *testing.T) {
+	t.Setenv("TRACEPARENT", "")
+
+	tp, err := envCarrierTraceparent()
+	if err != nil {
+		t.Fatalf("envCarrierTraceparent() returned an unexpected error: %s", err)
+	}
+	if tp.Initialized {
+		t.Error("expected an uninitialized traceparent when TRACEPARENT is unset")
+	}
+}
+
+// TestInjectTraceparentStrict proves the emit side only ever produces
+// spec-valid, lower-case W3C, even when the source was parsed from upper-case.
+func TestInjectTraceparentStrict(t *testing.T) {
+	t.Setenv("TRACEPARENT", "00-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-BBBBBBBBBBBBBBBB-01")
+	tp, err := envCarrierTraceparent()
+	if err != nil {
+		t.Fatalf("setup parse failed: %s", err)
+	}
+
+	got := map[string]string{}
+	injectTraceparent(tp, func(k, v string) { got[k] = v })
+
+	want := "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"
+	if got["TRACEPARENT"] != want {
+		t.Errorf("expected child TRACEPARENT=%q, got %q (full map: %v)", want, got["TRACEPARENT"], got)
+	}
+}
+
+// TestInjectTraceparentSkipsInvalid proves we never emit a traceparent that
+// would fail otel spec validation (e.g. an all-zero context).
+func TestInjectTraceparentSkipsInvalid(t *testing.T) {
+	// --tp-ignore-env yields a zeroed-but-Initialized traceparent, the realistic
+	// "initialized yet invalid" case we must not propagate.
+	zeroed := DefaultConfig().WithTraceparentIgnoreEnv(true).LoadTraceparent()
+	called := false
+	injectTraceparent(zeroed, func(k, v string) { called = true })
+	if called {
+		t.Error("an all-zero/invalid traceparent must not be emitted into the child env")
+	}
+}


### PR DESCRIPTION
Closes #33. Part of #31 (mirrors equinix-labs/otel-cli#390).

Routes otel-cli's environment-variable trace context propagation through the shared `go.opentelemetry.io/contrib/propagators/envcar` carrier instead of hand-formatting `TRACEPARENT=` strings.

## Design: Postel's law (per maintainer guidance)
**Accept leniently, emit strictly.**

- **Read** — `envcar.Carrier.Get("traceparent")` (spec key-normalization) parsed by otel-cli's existing lenient W3C parser. Upper-case hex and other lenient input is still **accepted and downcased**, not rejected. The standard `propagation.TraceContext` propagator is deliberately *not* used on the read side because it's spec-strict (rejects upper-case + all-zero).
- **Emit** — injection is routed through `propagation.TraceContext.Inject` + an `envcar.Carrier{SetEnvFunc}`, which guarantees **only spec-valid lower-case W3C** is ever written into a child process env, and refuses to emit an invalid/all-zero context.

New `otelcli/propagation.go` holds the bridge: `envCarrierTraceparent`, `injectTraceparent`, `spanContextFromTraceparent`. `config_span.go` reads through it; `exec.go` injects the child env through it.

## Compatibility
- `--tp-*` flags, `OTEL_CLI_*` env vars, `--tp-required`/`--tp-ignore-env`, the `{{traceparent}}` arg substitution, and the shell-sourceable `tp-carrier` **file** format are unchanged (`w3c/traceparent` stays the file parser/encoder — envcar is env-only).
- The existing upper-case-`TRACEPARENT` fixture stays green: we still accept it and already emit lower-case.

## Tests
- `otelcli/propagation_test.go` — graceful upper-case read, empty carrier, strict lower-case emit, skip-invalid emit. Each verified to fail when the implementation is broken.
- Functional fixture — `otel-cli exec` normalizes an upper-case `TRACEPARENT` into a strict lower-case value in the child's environment (proven to bite).

## Verification
- `go build` ✅ · `go vet ./...` ✅ · `gofmt -l .` clean ✅ · `go test ./...` (full functional + unit) ✅

## Follow-ups (noted, out of scope)
- #34 — TRACESTATE + BAGGAGE via a composite propagator.
- Pre-existing `{{traceparent}}` shadowing in exec non-recording mode; `w3c/traceparent.LoadFromEnv` now has no production callers. (tracked in docs/issues.md)

Refs #31, #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)